### PR TITLE
Enforce UTF-8 encoding.

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibrary.java
+++ b/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibrary.java
@@ -1,11 +1,16 @@
 package com.gliwka.hyperscan.jna;
 
+import java.util.Map;
+import java.util.HashMap;
 import com.sun.jna.*;
 import com.sun.jna.ptr.PointerByReference;
 
 
 public interface HyperscanLibrary extends Library{
-    HyperscanLibrary INSTANCE = (HyperscanLibrary) Native.loadLibrary("hs", HyperscanLibrary.class);
+    Map opts = new HashMap() { {
+        put(OPTION_STRING_ENCODING, "UTF-8");
+    }};
+    HyperscanLibrary INSTANCE = (HyperscanLibrary) Native.loadLibrary("hs", HyperscanLibrary.class, opts);
 
     String hs_version();
 

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -4,6 +4,7 @@ import com.sun.jna.*;
 import com.gliwka.hyperscan.jna.*;
 import com.sun.jna.ptr.PointerByReference;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -74,7 +75,9 @@ public class Scanner {
 
         final LinkedList<Match> matches = new LinkedList<Match>();
 
-        final int[] byteToIndex = Util.utf8ByteIndexesMapping(input);
+        final byte[] utf8bytes =input.getBytes(StandardCharsets.UTF_8);
+        int bytesLength = utf8bytes.length;
+        final int[] byteToIndex = Util.utf8ByteIndexesMapping(input, bytesLength);
 
         HyperscanLibrary.match_event_handler matchHandler = new HyperscanLibrary.match_event_handler() {
             public int invoke(int id, long from, long to, int flags, Pointer context) {
@@ -92,7 +95,7 @@ public class Scanner {
             }
         };
 
-        int hsError = HyperscanLibrary.INSTANCE.hs_scan(dbPointer, input, input.getBytes().length,
+        int hsError = HyperscanLibrary.INSTANCE.hs_scan(dbPointer, input, bytesLength,
                 0, scratch, matchHandler, Pointer.NULL);
 
         if(hsError != 0)

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Util.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Util.java
@@ -19,8 +19,8 @@ class Util {
         return bitValue;
     }
 
-    static int[] utf8ByteIndexesMapping(String s) {
-        int[] byteIndexes = new int[s.getBytes().length];
+    static int[] utf8ByteIndexesMapping(String s, int bytesLength) {
+        int[] byteIndexes = new int[bytesLength];
         int currentByte = 0;
 
         for (int stringPosition = 0; stringPosition < s.length(); stringPosition++) {


### PR DESCRIPTION
Currently the wrapper implicitly uses the system's default encoding.  If this is something other than UTF-8, `Util.utf8ByteIndexesMapping` can throw an out of range exceptions it assumes that the byte array represents an UTF-8 encoding of the string.

The pull request changes things to:
- Not depend on the default system encoding when calling String.getBytes.
- Not depend on the default system encoding when JNA transcodes Java Strings into C/C++ char arrays/pointers.
- Call String.getBytes once.  This operation encodes the internal UTF-16 char array into UTF-8.  It should not be called twice for the same string.