### PR TITLE
JNA direct mapping

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibrary.java
+++ b/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibrary.java
@@ -6,10 +6,11 @@ import com.sun.jna.*;
 import com.sun.jna.ptr.PointerByReference;
 
 
-public interface HyperscanLibrary extends Library{
+public interface HyperscanLibrary extends Library {
     Map opts = new HashMap() { {
         put(OPTION_STRING_ENCODING, "UTF-8");
     }};
+
     HyperscanLibrary INSTANCE = (HyperscanLibrary) Native.loadLibrary("hs", HyperscanLibrary.class, opts);
 
     String hs_version();

--- a/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
+++ b/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
@@ -1,0 +1,12 @@
+package com.gliwka.hyperscan.jna;
+
+import com.sun.jna.*;
+
+public class HyperscanLibraryDirect {
+
+    public static native int hs_scan(Pointer database, String data, int length, int flags, Pointer scratch, HyperscanLibrary.match_event_handler callback, Pointer context);
+
+    static {
+        Native.register("hs");
+    }
+}

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -51,7 +51,7 @@ public class Scanner {
      * @throws Throwable Throws if out of memory or platform not supported
      * or if the allocation fails
      */
-    public synchronized void allocScratch(final Database db) throws Throwable {
+    public void allocScratch(final Database db) throws Throwable {
         Pointer dbPointer = db.getPointer();
 
         int hsError = HyperscanLibrary.INSTANCE.hs_alloc_scratch(dbPointer, scratchReference);
@@ -78,7 +78,7 @@ public class Scanner {
      * @return List of Matches
      * @throws Throwable Throws if out of memory or platform not supported
      */
-    public synchronized List<Match> scan(final Database db, final String input) throws Throwable {
+    public List<Match> scan(final Database db, final String input) throws Throwable {
         Pointer dbPointer = db.getPointer();
 
         scratch = scratchReference.getValue();

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -90,7 +90,7 @@ public class Scanner {
         final int[] byteToIndex = Util.utf8ByteIndexesMapping(input, bytesLength);
 
         matchedIds.clear();
-        int hsError = HyperscanLibrary.INSTANCE.hs_scan(dbPointer, input, bytesLength,
+        int hsError = HyperscanLibraryDirect.hs_scan(dbPointer, input, bytesLength,
                 0, scratch, matchHandler, Pointer.NULL);
 
         if(hsError != 0)


### PR DESCRIPTION
This PR makes use of JNA direct mapping for the `hs_scan` Hyperscan library method.  I only direct map that method, as the whole API can't be direct mapped (direct mapping does not support array of strings or structures as argument) and it is the only performance critical method.  In my microbenchmark is produced ~20% call time improvement.  My application so marginal improvement of ~4%, but unexpectedly time spent in garbage collection appears to have dropped by two thirds, although it was already pretty low.

I also removed the `synchronize` keywords from a couple of methods in `Scanner`.  The documentation already states you should use one instance of `Scanner` per thread, so the keyword is not needed and there is no expectation that multiple threads will call these methods concurrently.