### PR TITLE
Avoid some work in the fast path of Scanner.scan.

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -88,7 +88,6 @@ public class Scanner implements Closeable {
 
         final byte[] utf8bytes =input.getBytes(StandardCharsets.UTF_8);
         int bytesLength = utf8bytes.length;
-        final int[] byteToIndex = Util.utf8ByteIndexesMapping(input, bytesLength);
 
         matchedIds.clear();
         int hsError = HyperscanLibraryDirect.hs_scan(dbPointer, input, bytesLength,
@@ -101,6 +100,7 @@ public class Scanner implements Closeable {
         if(matchedIds.isEmpty())
             return noMatches;
 
+        final int[] byteToIndex = Util.utf8ByteIndexesMapping(input, bytesLength);
         final LinkedList<Match> matches = new LinkedList<Match>();
         matchedIds.forEach( tuple -> {
             int id = (int)tuple[0];

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -86,8 +86,8 @@ public class Scanner implements Closeable {
     public List<Match> scan(final Database db, final String input) throws Throwable {
         Pointer dbPointer = db.getPointer();
 
-        final byte[] utf8bytes =input.getBytes(StandardCharsets.UTF_8);
-        int bytesLength = utf8bytes.length;
+        final byte[] utf8bytes = input.getBytes(StandardCharsets.UTF_8);
+        final int bytesLength = utf8bytes.length;
 
         matchedIds.clear();
         int hsError = HyperscanLibraryDirect.hs_scan(dbPointer, input, bytesLength,
@@ -95,7 +95,6 @@ public class Scanner implements Closeable {
 
         if(hsError != 0)
             throw Util.hsErrorIntToException(hsError);
-
 
         if(matchedIds.isEmpty())
             return noMatches;

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -6,6 +6,7 @@ import com.sun.jna.ptr.PointerByReference;
 import java.io.*;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -64,6 +65,7 @@ public class Scanner implements Closeable {
     }
 
     private LinkedList<long[]> matchedIds = new LinkedList<>();
+    private List<Match> noMatches = Collections.emptyList();
 
     private HyperscanLibrary.match_event_handler matchHandler = new HyperscanLibrary.match_event_handler() {
         public int invoke(int id, long from, long to, int flags, Pointer context) {
@@ -84,8 +86,6 @@ public class Scanner implements Closeable {
     public List<Match> scan(final Database db, final String input) throws Throwable {
         Pointer dbPointer = db.getPointer();
 
-        final LinkedList<Match> matches = new LinkedList<Match>();
-
         final byte[] utf8bytes =input.getBytes(StandardCharsets.UTF_8);
         int bytesLength = utf8bytes.length;
         final int[] byteToIndex = Util.utf8ByteIndexesMapping(input, bytesLength);
@@ -98,6 +98,10 @@ public class Scanner implements Closeable {
             throw Util.hsErrorIntToException(hsError);
 
 
+        if(matchedIds.isEmpty())
+            return noMatches;
+
+        final LinkedList<Match> matches = new LinkedList<Match>();
         matchedIds.forEach( tuple -> {
             int id = (int)tuple[0];
             long from = tuple[1];

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -59,6 +59,8 @@ public class Scanner implements Closeable {
 
         if(hsError != 0)
             throw new OutOfMemoryError("Not enough memory to allocate scratch space");
+
+        scratch = scratchReference.getValue();
     }
 
     private LinkedList<long[]> matchedIds = new LinkedList<>();
@@ -81,8 +83,6 @@ public class Scanner implements Closeable {
      */
     public List<Match> scan(final Database db, final String input) throws Throwable {
         Pointer dbPointer = db.getPointer();
-
-        scratch = scratchReference.getValue();
 
         final LinkedList<Match> matches = new LinkedList<Match>();
 


### PR DESCRIPTION
- Avoid getting the strach pointer on each scan call.
- Avoid allocating a LinkedList on most calls to scan.
- Avoid calls to Util.utf8ByteIndexesMapping on most calls to scan.
